### PR TITLE
C++ builds now, down to one failing test.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -115,3 +115,5 @@ UpgradeLog*.XML
 /.vs/DynamicInterop/v15/Solution.VC.db-wal
 /.vs/DynamicInterop/v15/Server/sqlite3/db.lock
 /.vs/DynamicInterop/v15/Server/sqlite3/storage.ide
+/.vs/DynamicInterop/v15/Browse.VC.opendb
+/.vs/DynamicInterop/v15/Server/sqlite3

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,13 @@ script:
 - dotnet restore
 - dotnet build --configuration Release --no-restore
 
-- export DynamicInteropTestLibPath='/home/travis/build/screig/dynamic-interop-dll/DynamicInterop.Tests/bin/Release/netcoreapp2.0'
+- cd DynamicInterop.Tests\test_native_library
+- cmake -H. -Bbuild
+- cmake --build build -- -j3
+- cd ../..
+
+- export DynamicInteropTestLibPath='/home/travis/build/screig/dynamic-interop-dll/DynamicInterop.Tests/test_native_library/build'
+
 - DYNINTEROP_BIN_DIR='/home/travis/build/screig/dynamic-interop-dll/DynamicInterop/bin/Release/netstandard2.0'
 - cd libdlwrap
 - make

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,12 @@ script:
 - dotnet restore
 - dotnet build --configuration Release --no-restore
 
-- cd DynamicInterop.Tests\test_native_library
+- cd DynamicInterop.Tests
+- cd test_native_library
 - cmake -H. -Bbuild
 - cmake --build build -- -j3
-- cd ../..
+- cd ..
+- cd ..
 
 - export DynamicInteropTestLibPath='/home/travis/build/screig/dynamic-interop-dll/DynamicInterop.Tests/test_native_library/build'
 

--- a/DynamicInterop.Tests/test_native_library/CMakeLists.txt
+++ b/DynamicInterop.Tests/test_native_library/CMakeLists.txt
@@ -1,0 +1,64 @@
+cmake_minimum_required(VERSION 3.0.0 FATAL_ERROR)
+
+################### Variables. ####################
+# Change if you want modify path or other values. #
+###################################################
+
+set(PROJECT_NAME test_native_library)
+# Folders files
+set(CPP_DIR_1 ./)
+set(CPP_DIR_2 ./)
+set(HEADER_DIR_1 )
+
+############## CMake Project ################
+#        The main options of project        #
+#############################################
+
+project(${PROJECT_NAME} CXX)
+
+# Define Release by default.
+if(NOT CMAKE_BUILD_TYPE)
+  set(CMAKE_BUILD_TYPE "Release")
+  message(STATUS "Build type not specified: Use Release by default.")
+endif(NOT CMAKE_BUILD_TYPE)
+
+# Definition of Macros
+add_definitions(
+   -D_DEBUG 
+   -D_WINDOWS 
+   -D_USRDLL 
+   -DTEST_NATIVE_LIBRARY_EXPORTS 
+   -DUNICODE
+   -D_UNICODE
+)
+
+################# Flags ################
+# Defines Flags for Windows and Linux. #
+########################################
+
+if(MSVC)
+   set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} /W3 /Od /Zi /EHsc")
+   set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} /W3 /Od /Oi /Gy /Zi /EHsc")
+endif(MSVC)
+if(NOT MSVC)
+   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+   if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+       set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++")
+   endif()
+endif(NOT MSVC)
+
+################ Files ################
+#   --   Add files to project.   --   #
+#######################################
+
+file(GLOB SRC_FILES
+    ${CPP_DIR_1}/*.cpp
+    ${CPP_DIR_2}/*.cpp
+    ${HEADER_DIR_1}/*.h
+)
+
+# Add library to build.
+add_library(${PROJECT_NAME} SHARED
+   ${SRC_FILES}
+)
+

--- a/DynamicInterop.Tests/test_native_library/cmake instructions.txt
+++ b/DynamicInterop.Tests/test_native_library/cmake instructions.txt
@@ -1,0 +1,4 @@
+cmake -H. -Bbuild
+cmake --build build -- -j3
+
+The first command will creates CMake configuration files inside folder build and the second one will generate the output in bin folder

--- a/DynamicInterop.sln
+++ b/DynamicInterop.sln
@@ -1,13 +1,13 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 14
-VisualStudioVersion = 14.0.25420.1
+# Visual Studio 15
+VisualStudioVersion = 15.0.27009.1
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DynamicInterop", "DynamicInterop\DynamicInterop.csproj", "{37E8DF32-0D37-418E-B976-10F4B36A0073}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DynamicInterop", "DynamicInterop\DynamicInterop.csproj", "{37E8DF32-0D37-418E-B976-10F4B36A0073}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DynamicInterop.Tests", "DynamicInterop.Tests\DynamicInterop.Tests.csproj", "{CA934BF8-EC5B-49F5-8F52-25F3B11072E6}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DynamicInterop.Tests", "DynamicInterop.Tests\DynamicInterop.Tests.csproj", "{CA934BF8-EC5B-49F5-8F52-25F3B11072E6}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DynamicInterop.TestApp", "DynamicInterop.TestApp\DynamicInterop.TestApp.csproj", "{46208A0E-F95F-4B1E-A396-0F715BA6B87A}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DynamicInterop.TestApp", "DynamicInterop.TestApp\DynamicInterop.TestApp.csproj", "{46208A0E-F95F-4B1E-A396-0F715BA6B87A}"
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "test_native_library", "DynamicInterop.Tests\test_native_library\test_native_library.vcxproj", "{32E08C93-DB46-4A93-8FE7-5791E088B2A1}"
 EndProject
@@ -57,7 +57,8 @@ Global
 		{46208A0E-F95F-4B1E-A396-0F715BA6B87A}.Release|x64.Build.0 = Release|Any CPU
 		{46208A0E-F95F-4B1E-A396-0F715BA6B87A}.Release|x86.ActiveCfg = Release|Any CPU
 		{46208A0E-F95F-4B1E-A396-0F715BA6B87A}.Release|x86.Build.0 = Release|Any CPU
-		{32E08C93-DB46-4A93-8FE7-5791E088B2A1}.Debug|Any CPU.ActiveCfg = Debug|Win32
+		{32E08C93-DB46-4A93-8FE7-5791E088B2A1}.Debug|Any CPU.ActiveCfg = Debug|x64
+		{32E08C93-DB46-4A93-8FE7-5791E088B2A1}.Debug|Any CPU.Build.0 = Debug|x64
 		{32E08C93-DB46-4A93-8FE7-5791E088B2A1}.Debug|x64.ActiveCfg = Debug|x64
 		{32E08C93-DB46-4A93-8FE7-5791E088B2A1}.Debug|x64.Build.0 = Debug|x64
 		{32E08C93-DB46-4A93-8FE7-5791E088B2A1}.Debug|x86.ActiveCfg = Debug|Win32
@@ -70,6 +71,9 @@ Global
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {3F12B32B-328B-4BD8-A08E-1498C924B167}
 	EndGlobalSection
 	GlobalSection(MonoDevelopProperties) = preSolution
 		StartupItem = DynamicInterop.TestApp\DynamicInterop.TestApp.csproj

--- a/DynamicInterop.sln
+++ b/DynamicInterop.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.27009.1
+VisualStudioVersion = 15.0.27019.1
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DynamicInterop", "DynamicInterop\DynamicInterop.csproj", "{37E8DF32-0D37-418E-B976-10F4B36A0073}"
 EndProject
@@ -58,7 +58,6 @@ Global
 		{46208A0E-F95F-4B1E-A396-0F715BA6B87A}.Release|x86.ActiveCfg = Release|Any CPU
 		{46208A0E-F95F-4B1E-A396-0F715BA6B87A}.Release|x86.Build.0 = Release|Any CPU
 		{32E08C93-DB46-4A93-8FE7-5791E088B2A1}.Debug|Any CPU.ActiveCfg = Debug|x64
-		{32E08C93-DB46-4A93-8FE7-5791E088B2A1}.Debug|Any CPU.Build.0 = Debug|x64
 		{32E08C93-DB46-4A93-8FE7-5791E088B2A1}.Debug|x64.ActiveCfg = Debug|x64
 		{32E08C93-DB46-4A93-8FE7-5791E088B2A1}.Debug|x64.Build.0 = Debug|x64
 		{32E08C93-DB46-4A93-8FE7-5791E088B2A1}.Debug|x86.ActiveCfg = Debug|Win32

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
-dev : https://travis-ci.org/screig/dynamic-interop-dll.svg?branch=devel    master: https://travis-ci.org/screig/dynamic-interop-dll.svg?branch=master
+
+[![Dev Build Status](https://travis-ci.org/screig/dynamic-interop-dll.svg?branch=devel )](https://github.com/screig/dynamic-interop-dll)
+[![Master Build Status](https://travis-ci.org/screig/dynamic-interop-dll.svg?branch=master )](https://github.com/screig/dynamic-interop-dll)
+
 
 dynamic-interop-dll
 ===================

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+dev : https://travis-ci.org/screig/dynamic-interop-dll.svg?branch=devel    master: https://travis-ci.org/screig/dynamic-interop-dll.svg?branch=master
+
 dynamic-interop-dll
 ===================
 


### PR DESCRIPTION
Hi

I got the c++ project to build under Linux on travis CI, there is now a cmake file in the C++ directory. The code can now find the native library, however one of the 7 tests fails and it looks like a [genuine failure](https://travis-ci.org/screig/dynamic-interop-dll/builds/292497225). I'm not sure how to fix that.

Note, as the project owner you will need to set up travis yourself. Currently the code links to my travis account, so a few minor changes need to made. For example in the travis.yml file there are some lines where I set the path:

```
- export DynamicInteropTestLibPath='/home/travis/build/screig/dynamic-interop-dll/DynamicInterop.Tests/test_native_library/build'

- DYNINTEROP_BIN_DIR='/home/travis/build/screig/dynamic-interop-dll/DynamicInterop/bin/Release/netstandard2.0'
```
which as you can see includes my username (screig). Travis CI only allows you to build project you own, I believe, could be wrong. So I can build the fork, but if you pull this in. You will need to edit this and the icons on the readme page.

Thanks
Sean




